### PR TITLE
fix: do not require class and function docstrings in tests

### DIFF
--- a/template/tests/test_component.py.jinja
+++ b/template/tests/test_component.py.jinja
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """
+<provide a high-level test description>
 """
+
+# pylint: disable=(missing-class-docstring,missing-function-docstring
 
 import unittest
 

--- a/template/tests/test_functions.py.jinja
+++ b/template/tests/test_functions.py.jinja
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """
+<provide a high-level test description>
 """
+
+# pylint: disable=(missing-class-docstring,missing-function-docstring
 
 import unittest
 


### PR DESCRIPTION
It's useful to run pylint on tests but we don't need to document them
as thoroughly as our code. Do not deduct style points if a test fails
to provide class or function docstrings.